### PR TITLE
feat: 지출 crud 로그인 사용자 기준으로 member 설정 로직 추가

### DIFF
--- a/src/main/java/capstone/donworry/expense/controller/ExpenseController.java
+++ b/src/main/java/capstone/donworry/expense/controller/ExpenseController.java
@@ -6,9 +6,12 @@ import capstone.donworry.expense.dto.ExpenseResponseDTO;
 import capstone.donworry.expense.domain.Expense;
 import capstone.donworry.expense.service.ExpenseService;
 import capstone.donworry.global.response.DataResponseDTO;
+import capstone.donworry.oauth.kakao.repository.MemberRepository;
+import capstone.donworry.oauth.kakao.security.CustomUserDetails;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -20,6 +23,7 @@ import java.util.stream.Collectors;
 public class ExpenseController {
 
     private final ExpenseService expenseService;
+    private final MemberRepository memberRepository;
 
 
     @GetMapping
@@ -32,11 +36,13 @@ public class ExpenseController {
         return ResponseEntity.ok(DataResponseDTO.success(expenseResponseDTOList));
     }
 
-    @GetMapping("/{id}")
+    @GetMapping("{id}")
     public ResponseEntity<DataResponseDTO<ExpenseResponseDTO>> getExpenseById(
-            @PathVariable Long id){
+            @PathVariable Long id,
+            @AuthenticationPrincipal CustomUserDetails userDetails){
 
-        Expense expense = expenseService.getExpenseById(id);
+        Long memberId = userDetails.getMemberId();
+        Expense expense = expenseService.getExpenseById(id, memberId);
         ExpenseResponseDTO expenseResponseDTO = ExpenseResponseDTO.from(expense);
 
         return ResponseEntity.status(HttpStatus.OK)
@@ -46,9 +52,11 @@ public class ExpenseController {
 
     @PostMapping()
     public ResponseEntity<DataResponseDTO<CreatedIdResponseDTO>> addExpense(
-            @RequestBody ExpenseRequestDTO expenseRequestDTO){
-        Expense expense = expenseRequestDTO.toEntity();
-        Long savedId = expenseService.addExpense(expense);
+            @RequestBody ExpenseRequestDTO expenseRequestDTO,
+            @AuthenticationPrincipal CustomUserDetails userDetails){
+
+        Long memberId = userDetails.getMemberId();
+        Long savedId = expenseService.addExpense(expenseRequestDTO, memberId);
 
         return ResponseEntity.status(HttpStatus.OK)
                 .body(DataResponseDTO.success(new CreatedIdResponseDTO(savedId)));
@@ -56,8 +64,12 @@ public class ExpenseController {
 
 
     @DeleteMapping("/{id}")
-    public ResponseEntity<DataResponseDTO<Void>> deleteExpense(@PathVariable long id){
-        expenseService.deleteExpense(id);
+    public ResponseEntity<DataResponseDTO<Void>> deleteExpense(
+            @PathVariable Long id,
+            @AuthenticationPrincipal CustomUserDetails userDetails){
+
+        Long memberId = userDetails.getMemberId();
+        expenseService.deleteExpense(id, memberId);
 
         return ResponseEntity.status(HttpStatus.OK)
                 .body(DataResponseDTO.success(null));
@@ -66,9 +78,12 @@ public class ExpenseController {
 
     @PutMapping("/{id}")
     public ResponseEntity<DataResponseDTO<Expense>> updateExpense(
-            @PathVariable long id,
-            @RequestBody ExpenseRequestDTO expenseRequestDTO){
-        Expense updateExpense = expenseService.updateExpense(id, expenseRequestDTO);
+            @PathVariable Long id,
+            @RequestBody ExpenseRequestDTO expenseRequestDTO,
+            @AuthenticationPrincipal CustomUserDetails userDetails){
+
+        Long memberId = userDetails.getMemberId();
+        Expense updateExpense = expenseService.updateExpense(id, memberId, expenseRequestDTO);
 
         return ResponseEntity.status(HttpStatus.OK)
                 .body(DataResponseDTO.success(updateExpense));

--- a/src/main/java/capstone/donworry/expense/domain/Expense.java
+++ b/src/main/java/capstone/donworry/expense/domain/Expense.java
@@ -1,5 +1,6 @@
 package capstone.donworry.expense.domain;
 
+import capstone.donworry.oauth.kakao.domain.Member;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -35,26 +36,31 @@ public class Expense {
     @Column(name = "payment", nullable = false)
     private PaymentMethod payment;
 
-//    @ManyToOne(fetch = FetchType.LAZY)  // 사용자:지출=n:1
-//    @JoinColumn(name = "user_id", nullable = false)
-//    private User user;
+    @Column(name = "note")
+    private String note;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
 
     @Builder
-    public Expense(String title, Long amount, LocalDate expenseDate, ExpenseCategory category, PaymentMethod payment) {
+    public Expense(String title, Long amount, LocalDate expenseDate, ExpenseCategory category, PaymentMethod payment, String note, Member member) {
         this.title = title;
         this.amount = amount;
         this.expenseDate = expenseDate;
         this.category = category;
         this.payment = payment;
-//        this.user = user;
+        this.note = note;
+        this.member = member;
     }
 
-    public void update(String title, Long amount, LocalDate expenseDate, ExpenseCategory category, PaymentMethod payment) {
+    public void update(String title, Long amount, LocalDate expenseDate, ExpenseCategory category, PaymentMethod payment, String note, Member member) {
         this.title = title;
         this.amount = amount;
         this.expenseDate = expenseDate;
         this.category = category;
         this.payment = payment;
-//        this.user = user;
+        this.note = note;
+        this.member = member;
     }
 }

--- a/src/main/java/capstone/donworry/expense/dto/ExpenseRequestDTO.java
+++ b/src/main/java/capstone/donworry/expense/dto/ExpenseRequestDTO.java
@@ -3,6 +3,7 @@ package capstone.donworry.expense.dto;
 import capstone.donworry.expense.domain.Expense;
 import capstone.donworry.expense.domain.ExpenseCategory;
 import capstone.donworry.expense.domain.PaymentMethod;
+import capstone.donworry.oauth.kakao.domain.Member;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -18,17 +19,19 @@ public class ExpenseRequestDTO {
     private LocalDate expenseDate;
     private ExpenseCategory category;
     private PaymentMethod payment;
-//    private User user;
+    private String note;
+    private Long memberId;
 
 
-    public Expense toEntity() {
+    public Expense toEntity(Member member) {
         return Expense.builder()
                 .title(title)
                 .amount(amount)
                 .expenseDate(expenseDate)
                 .category(category)
                 .payment(payment)
-//                .user(user)
+                .note(note)
+                .member(member)
                 .build();
     }
 }

--- a/src/main/java/capstone/donworry/expense/dto/ExpenseResponseDTO.java
+++ b/src/main/java/capstone/donworry/expense/dto/ExpenseResponseDTO.java
@@ -3,6 +3,7 @@ package capstone.donworry.expense.dto;
 import capstone.donworry.expense.domain.Expense;
 import capstone.donworry.expense.domain.ExpenseCategory;
 import capstone.donworry.expense.domain.PaymentMethod;
+import capstone.donworry.oauth.kakao.domain.Member;
 import lombok.Getter;
 
 import java.time.LocalDate;
@@ -15,14 +16,19 @@ public class ExpenseResponseDTO {
     private LocalDate expenseDate;
     private ExpenseCategory category;
     private PaymentMethod payment;
+    private String note;
+    private Member member;
+
 
     private ExpenseResponseDTO(String title, Long amount, LocalDate expenseDate,
-                               ExpenseCategory category, PaymentMethod payment) {
+                               ExpenseCategory category, PaymentMethod payment, String note, Member member) {
         this.title = title;
         this.amount = amount;
         this.expenseDate = expenseDate;
         this.category = category;
         this.payment = payment;
+        this.note = note;
+        this.member = member;
     }
 
     public static ExpenseResponseDTO from(Expense expense) {
@@ -31,7 +37,9 @@ public class ExpenseResponseDTO {
                 expense.getAmount(),
                 expense.getExpenseDate(),
                 expense.getCategory(),
-                expense.getPayment()
+                expense.getPayment(),
+                expense.getNote(),
+                expense.getMember()
         );
     }
 }

--- a/src/main/java/capstone/donworry/expense/repository/ExpenseRepository.java
+++ b/src/main/java/capstone/donworry/expense/repository/ExpenseRepository.java
@@ -3,5 +3,9 @@ package capstone.donworry.expense.repository;
 import capstone.donworry.expense.domain.Expense;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface ExpenseRepository extends JpaRepository<Expense, Long> {
+    Optional<Expense> findByExpenseIdAndMemberId(Long expenseId, Long memberId);
+
 }

--- a/src/main/java/capstone/donworry/expense/service/ExpenseService.java
+++ b/src/main/java/capstone/donworry/expense/service/ExpenseService.java
@@ -3,6 +3,8 @@ package capstone.donworry.expense.service;
 import capstone.donworry.expense.dto.ExpenseRequestDTO;
 import capstone.donworry.expense.domain.Expense;
 import capstone.donworry.expense.repository.ExpenseRepository;
+import capstone.donworry.oauth.kakao.domain.Member;
+import capstone.donworry.oauth.kakao.repository.MemberRepository;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -15,34 +17,42 @@ import java.util.List;
 public class ExpenseService {
 
     private final ExpenseRepository expenseRepository;
+    private final MemberRepository memberRepository;
 
     public List<Expense> getAllExpenses() {
         return expenseRepository.findAll();
     }
 
-    public Expense getExpenseById(Long id){
-        return expenseRepository.findById(id).
+    public Expense getExpenseById(Long id, Long memberId){
+        return expenseRepository.findByExpenseIdAndMemberId(id, memberId).
                 orElseThrow(() -> new EntityNotFoundException("해당 ID의 데이터를 찾을 수 없습니다."));
     }
-    public Long addExpense(Expense expense){
+    public Long addExpense(ExpenseRequestDTO expenseRequestDTO, Long memberId){
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new EntityNotFoundException("존재하지 않는 사용자입니다."));
+        Expense expense = expenseRequestDTO.toEntity(member);
         Expense savedExpense =  expenseRepository.save(expense);
 
         return savedExpense.getExpenseId();
     }
 
-    public void deleteExpense(long id) {
-        expenseRepository.deleteById(id);
+    public void deleteExpense(Long id, Long memberId) {
+        Expense expense = expenseRepository.findByExpenseIdAndMemberId(id, memberId)
+                        .orElseThrow(() -> new EntityNotFoundException("해당 ID의 데이터를 찾을 수 없습니다."));
+        expenseRepository.delete(expense);
     }
 
     @Transactional
-    public Expense updateExpense(long id, ExpenseRequestDTO expenseRequestDTO){
-        Expense savedExpense = expenseRepository.findById(id)
+    public Expense updateExpense(Long id, Long memberId, ExpenseRequestDTO expenseRequestDTO){
+        Expense savedExpense = expenseRepository.findByExpenseIdAndMemberId(id, memberId)
                 .orElseThrow(() -> new EntityNotFoundException("해당 ID의 데이터를 찾을 수 없습니다."));
         savedExpense.update(expenseRequestDTO.getTitle(),
                 expenseRequestDTO.getAmount(),
                 expenseRequestDTO.getExpenseDate(),
                 expenseRequestDTO.getCategory(),
-                expenseRequestDTO.getPayment());
+                expenseRequestDTO.getPayment(),
+                expenseRequestDTO.getNote(),
+                savedExpense.getMember());
 
         return savedExpense;
     }


### PR DESCRIPTION
- 지출 내역 생성 시 현재 로그인된 사용자 정보를 활용하여 member 연관관계 설정
- ExpenseService에 memberId를 인자로 받아 검증 후 entity 생성하도록 변경
- ExpenseRequestDTO를 Controller → Service로 그대로 넘겨주는 구조로 수정
