### PR TITLE
feat: JWT & OAuth2 기반 로그인 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,10 +25,17 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
+
+	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity6'
+	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+	implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
+	implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
 	implementation 'com.h2database:h2'
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/capstone/donworry/global/response/ErrorCode.java
+++ b/src/main/java/capstone/donworry/global/response/ErrorCode.java
@@ -15,7 +15,8 @@ public enum ErrorCode {
 
     //실패 response
     INVALID_REQUEST(STATUS_FAIL, HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
-    ENTITY_NOT_FOUND(STATUS_FAIL, HttpStatus.NOT_FOUND , "해당 데이터를 찾을 수 없습니다");
+    ENTITY_NOT_FOUND(STATUS_FAIL, HttpStatus.NOT_FOUND , "해당 데이터를 찾을 수 없습니다"),
+    UNAUTHORIZED(STATUS_FAIL, HttpStatus.UNAUTHORIZED, "권한이 없습니다.");
 
     private final String status;
     private final HttpStatus httpStatus;

--- a/src/main/java/capstone/donworry/login/common/CustomUserDetails.java
+++ b/src/main/java/capstone/donworry/login/common/CustomUserDetails.java
@@ -1,0 +1,80 @@
+package capstone.donworry.login.common;
+
+import capstone.donworry.member.domain.Member;
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+@Getter
+public class CustomUserDetails implements UserDetails, OAuth2User {
+
+    private final Member member;
+    private final Map<String, Object> attributes;
+    private final String token;
+
+    // 일반 로그인
+    public CustomUserDetails(Member member) {
+        this(member, null, null);
+    }
+
+    // OAuth2 로그인
+    public CustomUserDetails(Member member, Map<String, Object> attributes, String token) {
+        this.member = member;
+        this.attributes = attributes;
+        this.token = token;
+    }
+
+    public Member getMember(){
+        return member;
+    }
+
+    @Override
+    public Map<String, Object> getAttributes() {
+        return attributes;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return List.of((GrantedAuthority) () -> "ROLE_" + member.getRole().name());
+    }
+
+    @Override
+    public String getName() {
+        return member.getName();
+    }
+
+    @Override
+    public String getPassword() {
+        return member.getPassword();
+    }
+
+    @Override
+    public String getUsername() {
+        return member.getLoginId();
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+}

--- a/src/main/java/capstone/donworry/login/common/LoginRequestDTO.java
+++ b/src/main/java/capstone/donworry/login/common/LoginRequestDTO.java
@@ -1,0 +1,14 @@
+package capstone.donworry.login.common;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class LoginRequestDTO {
+
+    private String loginId;
+    private String password;
+}

--- a/src/main/java/capstone/donworry/login/common/LoginResponseDTO.java
+++ b/src/main/java/capstone/donworry/login/common/LoginResponseDTO.java
@@ -1,0 +1,25 @@
+package capstone.donworry.login.common;
+
+import capstone.donworry.member.domain.Member;
+import capstone.donworry.member.domain.MemberRole;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class LoginResponseDTO {
+    private String token;
+    private String loginId;
+    private String name;
+    private MemberRole role;
+
+    public static LoginResponseDTO from(Member member, String token) {
+        return new LoginResponseDTO(
+                token,
+                member.getLoginId(),
+                member.getName(),
+                member.getRole()
+        );
+    }
+}
+

--- a/src/main/java/capstone/donworry/login/common/SecurityConfig.java
+++ b/src/main/java/capstone/donworry/login/common/SecurityConfig.java
@@ -1,0 +1,75 @@
+package capstone.donworry.login.common;
+
+import capstone.donworry.login.jwt.JwtAuthenticationFilter;
+import capstone.donworry.login.oauth.CustomOAuth2UserService;
+import capstone.donworry.login.oauth.OAuth2SuccessHandler;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final CustomOAuth2UserService customOauth2UserService;
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
+    private final OAuth2SuccessHandler oAuth2SuccessHandler;
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception{
+
+        http
+                .csrf(AbstractHttpConfigurer::disable)
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests(auth -> auth
+                                .requestMatchers("/api/admin/**").hasRole("ADMIN")
+                                .requestMatchers("/api/member/signup", "/api/jwt/login", "/api/oauth/login").permitAll()
+                                .anyRequest().authenticated()
+                );
+
+
+
+
+        http
+                .oauth2Login((auth) -> auth
+                        .userInfoEndpoint(userInfo -> userInfo
+                                .userService(customOauth2UserService))
+                        .successHandler(oAuth2SuccessHandler)
+                        .failureUrl("/api/oauth/login-fail")
+                );
+
+        http
+                .exceptionHandling(e -> e
+                        .authenticationEntryPoint((request, response, authException) -> {
+                            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+                            response.setContentType("application/json;charset=UTF-8");
+                            response.getWriter().write("{\"error\": \"Unauthorized access\"}");
+                        })
+                );
+
+
+        http
+                .logout((auth) -> auth
+                        .logoutUrl("api/oauth/logout")
+                        .deleteCookies("JSESSIONID"));
+
+
+        http.addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+
+        return http.build();
+    }
+
+    @Bean
+    public BCryptPasswordEncoder bCryptPasswordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/src/main/java/capstone/donworry/login/jwt/CustomUserDetailsService.java
+++ b/src/main/java/capstone/donworry/login/jwt/CustomUserDetailsService.java
@@ -1,0 +1,27 @@
+package capstone.donworry.login.jwt;
+
+import capstone.donworry.login.common.CustomUserDetails;
+import capstone.donworry.member.domain.Member;
+import capstone.donworry.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CustomUserDetailsService implements UserDetailsService {
+
+    private final MemberRepository memberRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String loginId) throws UsernameNotFoundException {
+
+        Member member = memberRepository.findByLoginId(loginId);
+        if(member == null) {
+            throw new UsernameNotFoundException("사용자를 찾을 수 없습니다.");
+        }
+        return new CustomUserDetails(member);
+    }
+}

--- a/src/main/java/capstone/donworry/login/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/capstone/donworry/login/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,63 @@
+package capstone.donworry.login.jwt;
+
+import io.jsonwebtoken.Claims;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.oauth2.jwt.JwtException;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtUtil jwtUtil;
+    private final CustomUserDetailsService userDetailsService;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+
+        // Authorization 헤더에서 토큰 추출
+        String authHeader = request.getHeader("Authorization");
+
+        if (authHeader != null && authHeader.startsWith("Bearer ")) {
+            String token = authHeader.substring(7);
+
+            try {
+                // 토큰에서 loginId 추출
+                Claims claims = jwtUtil.validateToken(token);
+                String loginId = claims.getSubject();
+
+                if (loginId != null && SecurityContextHolder.getContext().getAuthentication() == null) {
+                    UserDetails userDetails = userDetailsService.loadUserByUsername(loginId);
+
+                    UsernamePasswordAuthenticationToken authenticationToken =
+                            new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+
+                    authenticationToken.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+                    SecurityContextHolder.getContext().setAuthentication(authenticationToken);
+                }
+
+            } catch (JwtException e) {
+                response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+                response.setContentType("application/json;charset=UTF-8");
+                response.getWriter().write("{\"error\": \"Invalid or expired JWT token\"}");
+                return;
+            }
+        }
+
+        filterChain.doFilter(request, response);
+    }
+}
+

--- a/src/main/java/capstone/donworry/login/jwt/JwtLoginController.java
+++ b/src/main/java/capstone/donworry/login/jwt/JwtLoginController.java
@@ -1,0 +1,48 @@
+package capstone.donworry.login.jwt;
+
+import capstone.donworry.global.response.DataResponseDTO;
+import capstone.donworry.global.response.ErrorCode;
+import capstone.donworry.global.response.ResponseDTO;
+import capstone.donworry.login.common.LoginRequestDTO;
+import capstone.donworry.login.common.LoginResponseDTO;
+import capstone.donworry.member.domain.Member;
+import capstone.donworry.member.service.MemberService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/jwt")
+public class JwtLoginController {
+
+    private final MemberService memberService;
+    private final JwtUtil jwtUtil;
+
+
+    @PostMapping("/login")
+    public ResponseEntity<?> login(@RequestBody LoginRequestDTO loginRequestDTO) {
+        Member member = memberService.getLoginMemberByLoginId(loginRequestDTO.getLoginId());
+
+        if (member == null || !memberService.checkPassword(loginRequestDTO.getPassword(), member.getPassword())) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(
+                    new ResponseDTO(
+                            ErrorCode.UNAUTHORIZED.getStatus(),
+                            ErrorCode.UNAUTHORIZED.getHttpStatus(),
+                            "아이디 또는 비밀번호가 틀렸습니다."
+                    )
+            );
+        }
+
+        String token = jwtUtil.generateToken(member.getLoginId(), member.getRole().name());
+
+        LoginResponseDTO responseDTO = LoginResponseDTO.from(member, token);
+
+        return ResponseEntity.ok(DataResponseDTO.success(responseDTO));
+    }
+}
+

--- a/src/main/java/capstone/donworry/login/jwt/JwtUtil.java
+++ b/src/main/java/capstone/donworry/login/jwt/JwtUtil.java
@@ -1,0 +1,62 @@
+package capstone.donworry.login.jwt;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.oauth2.jwt.JwtException;
+import org.springframework.stereotype.Component;
+
+import java.security.Key;
+import java.util.Date;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class JwtUtil {
+
+
+    @Value("${spring.security.jwt.secret}")
+    private String secretKey;
+    private Key getSignKey() {
+        byte[] keyBytes = Decoders.BASE64.decode(secretKey);
+        return Keys.hmacShaKeyFor(keyBytes);
+    }
+
+    private final long expirationMs = 1000 * 60 * 60 * 24;
+
+    public String generateToken(String loginId, String role) {
+        String token = Jwts.builder()
+                .setSubject(loginId)
+                .claim("role", role)
+                .setIssuedAt(new Date())
+                .setExpiration(new Date(System.currentTimeMillis() + expirationMs))
+                .signWith(getSignKey(),SignatureAlgorithm.HS256)
+                .compact();
+
+        return token;
+    }
+
+
+    public Claims validateToken(String token) {
+        try {
+            return Jwts.parserBuilder()
+                    .setSigningKey(getSignKey())
+                    .build()
+                    .parseClaimsJws(token)
+                    .getBody();
+
+        } catch (JwtException | IllegalArgumentException e) {
+            log.warn("JWT 토큰 검증 실패: {}", e.getMessage());
+            throw e;
+        }
+    }
+
+
+
+}
+

--- a/src/main/java/capstone/donworry/login/oauth/CustomOAuth2UserService.java
+++ b/src/main/java/capstone/donworry/login/oauth/CustomOAuth2UserService.java
@@ -1,0 +1,62 @@
+package capstone.donworry.login.oauth;
+
+import capstone.donworry.login.common.CustomUserDetails;
+import capstone.donworry.login.jwt.JwtUtil;
+import capstone.donworry.member.domain.Member;
+import capstone.donworry.member.domain.MemberRole;
+import capstone.donworry.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+
+import java.util.Map;
+import java.util.function.Function;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class CustomOAuth2UserService extends DefaultOAuth2UserService {
+
+    private final MemberRepository memberRepository;
+    private final JwtUtil jwtUtil;
+
+    private final Map<String, Function<Map<String, Object>, OAuth2UserInfo>> userInfoFactory = Map.of(
+//            "google", GoogleOAuth2UserInfo::new,
+            "kakao", KakaoOAuth2UserInfo::new
+    );
+
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+        OAuth2User oAuth2User = super.loadUser(userRequest);
+        String provider = userRequest.getClientRegistration().getRegistrationId();
+
+        OAuth2UserInfo oAuth2UserInfo = userInfoFactory.getOrDefault(provider, attrs -> {
+            throw new OAuth2AuthenticationException("지원하지 않는 provider: " + provider);
+        }).apply(oAuth2User.getAttributes());
+
+
+        String providerId = oAuth2UserInfo.getProviderId();
+        String loginId = provider + "_" + providerId;
+        String name = oAuth2UserInfo.getName();
+
+        Member member = memberRepository.findByLoginId(loginId);
+
+        if (member == null) {
+            member = Member.builder()
+                    .loginId(loginId)
+                    .name(name)
+                    .provider(provider)
+                    .providerId(providerId)
+                    .role(MemberRole.USER)
+                    .build();
+            memberRepository.save(member);
+        }
+        String token = jwtUtil.generateToken(member.getLoginId(), member.getRole().name());
+
+        return new CustomUserDetails(member, oAuth2User.getAttributes(), token);
+    }
+}

--- a/src/main/java/capstone/donworry/login/oauth/KakaoOAuth2UserInfo.java
+++ b/src/main/java/capstone/donworry/login/oauth/KakaoOAuth2UserInfo.java
@@ -1,0 +1,34 @@
+package capstone.donworry.login.oauth;
+
+import lombok.AllArgsConstructor;
+
+import java.util.Map;
+
+@AllArgsConstructor
+public class KakaoOAuth2UserInfo implements OAuth2UserInfo {
+
+    private Map<String, Object> attributes;
+
+    @Override
+    public String getProvider() {
+        return "kakao";
+    }
+
+    @Override
+    public String getProviderId() {
+        return attributes.get("id").toString();
+    }
+
+    @Override
+    public String getEmail() {
+        return (String) ((Map) attributes.get("kakao_account")).get("email");
+    }
+
+    @Override
+    public String getName() {
+        return (String) ((Map) attributes.get("properties")).get("nickname");
+    }
+}
+
+
+

--- a/src/main/java/capstone/donworry/login/oauth/OAuth2SuccessHandler.java
+++ b/src/main/java/capstone/donworry/login/oauth/OAuth2SuccessHandler.java
@@ -1,0 +1,38 @@
+package capstone.donworry.login.oauth;
+
+import capstone.donworry.login.common.CustomUserDetails;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.util.Map;
+
+@Component
+@RequiredArgsConstructor
+public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request,
+                                        HttpServletResponse response,
+                                        Authentication authentication) throws IOException {
+        CustomUserDetails userDetails = (CustomUserDetails) authentication.getPrincipal();
+        String token = userDetails.getToken();
+
+        Map<String, Object> responseBody = Map.of(
+                "token", token,
+                "username", userDetails.getUsername(),
+                "role", userDetails.getMember().getRole().name()
+        );
+
+        response.setStatus(HttpServletResponse.SC_OK);
+        response.setContentType("application/json;charset=UTF-8");
+        response.getWriter().write(objectMapper.writeValueAsString(Map.of("token", token)));
+    }
+}

--- a/src/main/java/capstone/donworry/login/oauth/OAuth2UserInfo.java
+++ b/src/main/java/capstone/donworry/login/oauth/OAuth2UserInfo.java
@@ -1,0 +1,8 @@
+package capstone.donworry.login.oauth;
+
+public interface OAuth2UserInfo {
+    String getProvider();
+    String getProviderId();
+    String getEmail();
+    String getName();
+}


### PR DESCRIPTION
JWT 로그인 API 구현
- JwtLoginController에서 로그인 요청 처리
- JwtUtil로 JWT 토큰 생성 및 검증 기능 구현
- JwtAuthenticationFilter를 통한 JWT 인증 필터 추가
- CustomUserDetailsService를 이용해 사용자 인증 처리

OAuth2 로그인 기능 구현
- CustomOAuth2UserService에서 Kakao 로그인 처리 및 자동 회원가입
- OAuth2SuccessHandler에서 JWT 토큰 발급 및 응답

common
- CustomUserDetails 클래스 통합 (일반 로그인 & OAuth 공통 처리)
