### PR TITLE
feat: 주간 통계 및 카테고리별 조회 구현

### DIFF
--- a/src/main/java/capstone/donworry/expectedExpenditure/dto/CreatedIdResponseDTO.java
+++ b/src/main/java/capstone/donworry/expectedExpenditure/dto/CreatedIdResponseDTO.java
@@ -1,5 +1,10 @@
 package capstone.donworry.expectedExpenditure.dto;
 
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
 public class CreatedIdResponseDTO {
     private Long id;
 

--- a/src/main/java/capstone/donworry/expense/controller/ExpenseController.java
+++ b/src/main/java/capstone/donworry/expense/controller/ExpenseController.java
@@ -36,7 +36,7 @@ public class ExpenseController {
         return ResponseEntity.ok(DataResponseDTO.success(expenseResponseDTOList));
     }
 
-    @GetMapping("{id}")
+    @GetMapping("/{id}")
     public ResponseEntity<DataResponseDTO<ExpenseResponseDTO>> getExpenseById(
             @PathVariable Long id,
             @AuthenticationPrincipal CustomUserDetails userDetails){
@@ -77,7 +77,7 @@ public class ExpenseController {
 
 
     @PutMapping("/{id}")
-    public ResponseEntity<DataResponseDTO<Expense>> updateExpense(
+    public ResponseEntity<DataResponseDTO<ExpenseResponseDTO>> updateExpense(
             @PathVariable Long id,
             @RequestBody ExpenseRequestDTO expenseRequestDTO,
             @AuthenticationPrincipal CustomUserDetails userDetails){
@@ -85,8 +85,9 @@ public class ExpenseController {
         Long memberId = userDetails.getMember().getId();
         Expense updateExpense = expenseService.updateExpense(id, memberId, expenseRequestDTO);
 
+        ExpenseResponseDTO expenseResponseDTO = ExpenseResponseDTO.from(updateExpense);
         return ResponseEntity.status(HttpStatus.OK)
-                .body(DataResponseDTO.success(updateExpense));
+                .body(DataResponseDTO.success(expenseResponseDTO));
     }
 }
 

--- a/src/main/java/capstone/donworry/expense/dto/ExpenseResponseDTO.java
+++ b/src/main/java/capstone/donworry/expense/dto/ExpenseResponseDTO.java
@@ -4,10 +4,14 @@ import capstone.donworry.expense.domain.Expense;
 import capstone.donworry.expense.domain.ExpenseCategory;
 import capstone.donworry.expense.domain.PaymentMethod;
 import capstone.donworry.member.domain.Member;
+import capstone.donworry.member.dto.MemberInExpenseDTO;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
 
-
+@Data
+@NoArgsConstructor
 public class ExpenseResponseDTO {
 
     private String title;
@@ -16,11 +20,11 @@ public class ExpenseResponseDTO {
     private ExpenseCategory category;
     private PaymentMethod payment;
     private String note;
-    private Member member;
+    private MemberInExpenseDTO member;
 
 
     private ExpenseResponseDTO(String title, Long amount, LocalDate expenseDate,
-                               ExpenseCategory category, PaymentMethod payment, String note, Member member) {
+                               ExpenseCategory category, PaymentMethod payment, String note, MemberInExpenseDTO member) {
         this.title = title;
         this.amount = amount;
         this.expenseDate = expenseDate;
@@ -38,7 +42,7 @@ public class ExpenseResponseDTO {
                 expense.getCategory(),
                 expense.getPayment(),
                 expense.getNote(),
-                expense.getMember()
+                MemberInExpenseDTO.from(expense.getMember())
         );
     }
 }

--- a/src/main/java/capstone/donworry/member/controller/MemberController.java
+++ b/src/main/java/capstone/donworry/member/controller/MemberController.java
@@ -25,11 +25,7 @@ public class MemberController {
 
     @PostMapping("/signup")
     public ResponseEntity<?> signup(
-            @RequestBody @Valid MemberJoinRequestDTO memberJoinRequestDTO,
-            BindingResult bindingResult) {
-        if (bindingResult.hasErrors()) {
-            return ResponseEntity.badRequest().body("입력값 오류");
-        }
+            @RequestBody @Valid MemberJoinRequestDTO memberJoinRequestDTO) {
 
         memberService.join(memberJoinRequestDTO);
         return ResponseEntity.ok(DataResponseDTO.successWithMessage("회원가입 완료", null));

--- a/src/main/java/capstone/donworry/member/dto/MemberInExpenseDTO.java
+++ b/src/main/java/capstone/donworry/member/dto/MemberInExpenseDTO.java
@@ -1,0 +1,20 @@
+package capstone.donworry.member.dto;
+
+import capstone.donworry.member.domain.Member;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+public class MemberInExpenseDTO {
+    private Long id;
+    private String username;
+
+
+    public static MemberInExpenseDTO from(Member member) {
+        MemberInExpenseDTO dto = new MemberInExpenseDTO();
+        dto.setId(member.getId());
+        dto.setUsername(member.getName());
+        return dto;
+    }
+}

--- a/src/main/java/capstone/donworry/statistics/controller/StatisticsController.java
+++ b/src/main/java/capstone/donworry/statistics/controller/StatisticsController.java
@@ -1,0 +1,77 @@
+package capstone.donworry.statistics.controller;
+
+import capstone.donworry.global.response.DataResponseDTO;
+import capstone.donworry.login.common.CustomUserDetails;
+import capstone.donworry.statistics.dto.DailyExpenseDTO;
+import capstone.donworry.statistics.dto.PaymentExpenseDTO;
+import capstone.donworry.statistics.service.StatisticsService;
+import capstone.donworry.statistics.dto.WeeklyExpenseDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDate;
+import java.time.temporal.TemporalAdjusters;
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/statistics")
+public class StatisticsController {
+
+    private final StatisticsService statisticsService;
+
+    @GetMapping("/weekly")
+    public ResponseEntity<DataResponseDTO<List<WeeklyExpenseDTO>>> getWeeklyExpenseByMonth(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestParam int year,
+            @RequestParam int month) {
+
+        LocalDate startDate = LocalDate.of(year, month, 1);
+        LocalDate endDate = startDate.with(TemporalAdjusters.lastDayOfMonth());
+
+
+        if (userDetails == null) {
+            // 인증 실패 상태임
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
+
+        Long memberId = userDetails.getMember().getId();
+        System.out.println("memberId = " + memberId);
+
+        List<WeeklyExpenseDTO> result = statisticsService.getWeeklyExpense(memberId, startDate, endDate);
+
+        return ResponseEntity.ok(DataResponseDTO.success(result));
+    }
+
+    @GetMapping("/daily")
+    public ResponseEntity<DataResponseDTO<List<DailyExpenseDTO>>> getDailyExpenseByWeek(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestParam("startDate") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
+            @RequestParam("endDate") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate) {
+
+        Long memberId = userDetails.getMember().getId();
+        List<DailyExpenseDTO> dailyStats = statisticsService.getDailyExpense(memberId, startDate, endDate);
+
+        return ResponseEntity.ok(DataResponseDTO.success(dailyStats));
+    }
+
+
+    @GetMapping("/weekly/payment-method")
+    public ResponseEntity<DataResponseDTO<List<PaymentExpenseDTO>>> getWeeklyPaymentStats(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestParam("startDate") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
+            @RequestParam("endDate") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate) {
+
+        Long memberId = userDetails.getMember().getId();
+        List<PaymentExpenseDTO> paymentStats = statisticsService.getWeeklyPaymentExpense(memberId, startDate, endDate);
+        return ResponseEntity.ok(DataResponseDTO.success(paymentStats));
+    }
+}
+

--- a/src/main/java/capstone/donworry/statistics/controller/StatisticsController.java
+++ b/src/main/java/capstone/donworry/statistics/controller/StatisticsController.java
@@ -1,11 +1,10 @@
 package capstone.donworry.statistics.controller;
 
+import capstone.donworry.expense.domain.ExpenseCategory;
 import capstone.donworry.global.response.DataResponseDTO;
 import capstone.donworry.login.common.CustomUserDetails;
-import capstone.donworry.statistics.dto.DailyExpenseDTO;
-import capstone.donworry.statistics.dto.PaymentExpenseDTO;
+import capstone.donworry.statistics.dto.*;
 import capstone.donworry.statistics.service.StatisticsService;
-import capstone.donworry.statistics.dto.WeeklyExpenseDTO;
 import lombok.RequiredArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
@@ -15,6 +14,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.time.LocalDate;
 import java.time.temporal.TemporalAdjusters;
@@ -43,28 +43,57 @@ public class StatisticsController {
         return ResponseEntity.ok(DataResponseDTO.success(result));
     }
 
-    @GetMapping("/daily")
-    public ResponseEntity<DataResponseDTO<List<DailyExpenseDTO>>> getDailyExpenseByWeek(
+    @GetMapping("/weekly/detail")
+    public ResponseEntity<DataResponseDTO<WeeklyDetailExpenseDTO>> getWeeklyDetailStatistics(
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @RequestParam("startDate") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
             @RequestParam("endDate") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate) {
 
         Long memberId = userDetails.getMember().getId();
-        List<DailyExpenseDTO> dailyStats = statisticsService.getDailyExpense(memberId, startDate, endDate);
+        WeeklyDetailExpenseDTO dto = statisticsService.getWeeklyDetailStatistics(memberId, startDate, endDate);
 
-        return ResponseEntity.ok(DataResponseDTO.success(dailyStats));
+        return ResponseEntity.ok(DataResponseDTO.success(dto));
     }
 
 
-    @GetMapping("/weekly/payment-method")
-    public ResponseEntity<DataResponseDTO<List<PaymentExpenseDTO>>> getWeeklyPaymentStats(
+    @GetMapping("/monthly/category")
+    public ResponseEntity<DataResponseDTO<MonthlyStatisticsDTO>> getMonthlyStatistics(
             @AuthenticationPrincipal CustomUserDetails userDetails,
-            @RequestParam("startDate") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
-            @RequestParam("endDate") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate) {
+            @RequestParam int year,
+            @RequestParam int month) {
 
         Long memberId = userDetails.getMember().getId();
-        List<PaymentExpenseDTO> paymentStats = statisticsService.getWeeklyPaymentExpense(memberId, startDate, endDate);
-        return ResponseEntity.ok(DataResponseDTO.success(paymentStats));
+        LocalDate startDate = LocalDate.of(year, month, 1);
+        LocalDate endDate = startDate.with(TemporalAdjusters.lastDayOfMonth());
+
+        MonthlyStatisticsDTO dto = statisticsService.getMonthlyStatistics(memberId, startDate, endDate);
+
+        return ResponseEntity.ok(DataResponseDTO.success(dto));
     }
+
+    @GetMapping("/monthly/category/detail")
+    public ResponseEntity<DataResponseDTO<CategoryExpenseDetailDTO>> getCategoryDetail(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestParam int year,
+            @RequestParam int month,
+            @RequestParam String category) {
+
+        Long memberId = userDetails.getMember().getId();
+        LocalDate startDate = LocalDate.of(year, month, 1);
+        LocalDate endDate = startDate.with(TemporalAdjusters.lastDayOfMonth());
+
+        ExpenseCategory categoryEnum;
+        try {
+            categoryEnum = ExpenseCategory.valueOf(category.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "존재하지 않는 카테고리입니다.");
+        }
+
+        CategoryExpenseDetailDTO dto = statisticsService.getCategoryExpenseDetail(memberId, categoryEnum, startDate, endDate);
+        return ResponseEntity.ok(DataResponseDTO.success(dto));
+    }
+
+
+
 }
 

--- a/src/main/java/capstone/donworry/statistics/controller/StatisticsController.java
+++ b/src/main/java/capstone/donworry/statistics/controller/StatisticsController.java
@@ -37,14 +37,7 @@ public class StatisticsController {
         LocalDate endDate = startDate.with(TemporalAdjusters.lastDayOfMonth());
 
 
-        if (userDetails == null) {
-            // 인증 실패 상태임
-            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
-        }
-
         Long memberId = userDetails.getMember().getId();
-        System.out.println("memberId = " + memberId);
-
         List<WeeklyExpenseDTO> result = statisticsService.getWeeklyExpense(memberId, startDate, endDate);
 
         return ResponseEntity.ok(DataResponseDTO.success(result));

--- a/src/main/java/capstone/donworry/statistics/dto/CategoryExpenseDTO.java
+++ b/src/main/java/capstone/donworry/statistics/dto/CategoryExpenseDTO.java
@@ -1,0 +1,16 @@
+package capstone.donworry.statistics.dto;
+
+import capstone.donworry.expense.domain.ExpenseCategory;
+import lombok.Data;
+import lombok.Getter;
+
+@Data
+@Getter
+public class CategoryExpenseDTO {
+    private ExpenseCategory category;
+    private Long totalAmount;
+    public CategoryExpenseDTO(ExpenseCategory category, Long totalAmount) {
+        this.category = category;
+        this.totalAmount = totalAmount;
+    }
+}

--- a/src/main/java/capstone/donworry/statistics/dto/CategoryExpenseDetailDTO.java
+++ b/src/main/java/capstone/donworry/statistics/dto/CategoryExpenseDetailDTO.java
@@ -1,0 +1,13 @@
+package capstone.donworry.statistics.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class CategoryExpenseDetailDTO {
+    private List<ExpenseItemDTO> expenses;
+    private List<PaymentExpenseDTO> paymentExpenses;
+}

--- a/src/main/java/capstone/donworry/statistics/dto/DailyExpenseDTO.java
+++ b/src/main/java/capstone/donworry/statistics/dto/DailyExpenseDTO.java
@@ -1,0 +1,17 @@
+package capstone.donworry.statistics.dto;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import java.time.LocalDate;
+
+@Data
+@NoArgsConstructor
+public class DailyExpenseDTO {
+    private LocalDate date;
+    private Long amount;
+
+    public DailyExpenseDTO(LocalDate date, Long amount) {
+        this.date = date;
+        this.amount = amount;
+    }
+}

--- a/src/main/java/capstone/donworry/statistics/dto/ExpenseItemDTO.java
+++ b/src/main/java/capstone/donworry/statistics/dto/ExpenseItemDTO.java
@@ -1,0 +1,17 @@
+package capstone.donworry.statistics.dto;
+
+import capstone.donworry.expense.domain.PaymentMethod;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+@AllArgsConstructor
+public class ExpenseItemDTO {
+    private Long id;
+    private String title;
+    private Long amount;
+    private PaymentMethod paymentMethod;
+    private LocalDate date;
+}

--- a/src/main/java/capstone/donworry/statistics/dto/MonthlyStatisticsDTO.java
+++ b/src/main/java/capstone/donworry/statistics/dto/MonthlyStatisticsDTO.java
@@ -1,0 +1,15 @@
+package capstone.donworry.statistics.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.util.List;
+@Data
+@AllArgsConstructor
+public class MonthlyStatisticsDTO {
+    private Long totalSpent;
+    private Long goalAmount;
+    private List<CategoryExpenseDTO> categoryExpenses;
+    private List<PaymentExpenseDTO> paymentMethodExpenses;
+}
+

--- a/src/main/java/capstone/donworry/statistics/dto/PaymentExpenseDTO.java
+++ b/src/main/java/capstone/donworry/statistics/dto/PaymentExpenseDTO.java
@@ -1,0 +1,16 @@
+package capstone.donworry.statistics.dto;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+public class PaymentExpenseDTO {
+    private String paymentMethod;
+    private Long totalAmount;
+
+    public PaymentExpenseDTO(String paymentMethod, Long totalAmount) {
+        this.paymentMethod = paymentMethod;
+        this.totalAmount = totalAmount;
+    }
+}

--- a/src/main/java/capstone/donworry/statistics/dto/PaymentExpenseDTO.java
+++ b/src/main/java/capstone/donworry/statistics/dto/PaymentExpenseDTO.java
@@ -1,15 +1,16 @@
 package capstone.donworry.statistics.dto;
 
+import capstone.donworry.expense.domain.PaymentMethod;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
 @Data
 @NoArgsConstructor
 public class PaymentExpenseDTO {
-    private String paymentMethod;
+    private PaymentMethod paymentMethod;
     private Long totalAmount;
 
-    public PaymentExpenseDTO(String paymentMethod, Long totalAmount) {
+    public PaymentExpenseDTO(PaymentMethod paymentMethod, Long totalAmount) {
         this.paymentMethod = paymentMethod;
         this.totalAmount = totalAmount;
     }

--- a/src/main/java/capstone/donworry/statistics/dto/WeeklyDetailExpenseDTO.java
+++ b/src/main/java/capstone/donworry/statistics/dto/WeeklyDetailExpenseDTO.java
@@ -1,0 +1,19 @@
+package capstone.donworry.statistics.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+public class WeeklyDetailExpenseDTO {
+    private List<DailyExpenseDTO> dailyExpenses;
+    private List<PaymentExpenseDTO> paymentExpenses;
+
+    public WeeklyDetailExpenseDTO(List<DailyExpenseDTO> dailyExpenses, List<PaymentExpenseDTO> paymentExpenses){
+        this.dailyExpenses = dailyExpenses;
+        this.paymentExpenses = paymentExpenses;
+    }
+}

--- a/src/main/java/capstone/donworry/statistics/dto/WeeklyExpenseDTO.java
+++ b/src/main/java/capstone/donworry/statistics/dto/WeeklyExpenseDTO.java
@@ -1,0 +1,28 @@
+package capstone.donworry.statistics.dto;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.cglib.core.Local;
+
+import java.time.LocalDate;
+
+@Data
+@NoArgsConstructor
+public class WeeklyExpenseDTO {
+    private int year;
+    private int week;
+    private Long totalSpent;
+    private LocalDate startDate;
+    private LocalDate endDate;
+    private Long dailyGoal;
+
+    public WeeklyExpenseDTO(int year, int week, Long totalSpent,
+                            LocalDate startDate, LocalDate endDate, Long dailyGoal) {
+        this.year = year;
+        this.week = week;
+        this.totalSpent = totalSpent;
+        this.startDate = startDate;
+        this.endDate = endDate;
+        this.dailyGoal = dailyGoal;
+    }
+}

--- a/src/main/java/capstone/donworry/statistics/repository/ExpenseStatisticsRepository.java
+++ b/src/main/java/capstone/donworry/statistics/repository/ExpenseStatisticsRepository.java
@@ -1,6 +1,7 @@
 package capstone.donworry.statistics.repository;
 
 import capstone.donworry.expense.domain.Expense;
+import capstone.donworry.expense.domain.ExpenseCategory;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -35,9 +36,48 @@ public interface ExpenseStatisticsRepository extends JpaRepository<Expense, Long
             "WHERE e.member.id = :memberId " +
             "AND e.expenseDate BETWEEN :startDate AND :endDate " +
             "GROUP BY e.payment")
-    List<Object[]> findWeeklyExpenseByPaymentMethod(@Param("memberId") Long memberId,
+    List<Object[]> findExpenseByPaymentMethod(@Param("memberId") Long memberId,
                                                     @Param("startDate") LocalDate startDate,
                                                     @Param("endDate") LocalDate endDate);
+
+
+    @Query("SELECT e.category, SUM(e.amount) " +
+            "FROM Expense e " +
+            "WHERE e.member.id = :memberId AND e.expenseDate BETWEEN :startDate AND :endDate " +
+            "GROUP BY e.category")
+    List<Object[]> findMonthlyCategoryExpense(@Param("memberId") Long memberId,
+                                              @Param("startDate") LocalDate startDate,
+                                              @Param("endDate") LocalDate endDate);
+
+    @Query("SELECT SUM(e.amount) " +
+            "FROM Expense e " +
+            "WHERE e.member.id = :memberId " +
+            "AND e.expenseDate BETWEEN :startDate AND :endDate")
+    Long findMonthlyTotalExpense(@Param("memberId") Long memberId,
+                                 @Param("startDate") LocalDate startDate,
+                                 @Param("endDate") LocalDate endDate);
+
+
+
+    @Query("""
+    SELECT e.expenseId, e.title, e.amount, e.payment, e.expenseDate
+    FROM Expense e
+    WHERE e.member.id = :memberId
+      AND e.category = :category
+      AND e.expenseDate BETWEEN :startDate AND :endDate
+    ORDER BY e.expenseDate DESC
+""")
+    List<Object[]> findExpensesByCategory(Long memberId, ExpenseCategory category, LocalDate startDate, LocalDate endDate);
+
+    @Query("""
+    SELECT e.payment, SUM(e.amount)
+    FROM Expense e
+    WHERE e.member.id = :memberId
+      AND e.category = :category
+      AND e.expenseDate BETWEEN :startDate AND :endDate
+    GROUP BY e.payment
+""")
+    List<Object[]> findPaymentSummaryByCategory(Long memberId, ExpenseCategory category, LocalDate startDate, LocalDate endDate);
 
 }
 

--- a/src/main/java/capstone/donworry/statistics/repository/ExpenseStatisticsRepository.java
+++ b/src/main/java/capstone/donworry/statistics/repository/ExpenseStatisticsRepository.java
@@ -1,0 +1,43 @@
+package capstone.donworry.statistics.repository;
+
+import capstone.donworry.expense.domain.Expense;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public interface ExpenseStatisticsRepository extends JpaRepository<Expense, Long> {
+
+    @Query("SELECT FUNCTION('YEAR', e.expenseDate) AS year, FUNCTION('WEEK', e.expenseDate) AS week, SUM(e.amount) " +
+            "FROM Expense e " +
+            "WHERE e.member.id = :memberId AND e.expenseDate BETWEEN :startDate AND :endDate " +
+            "GROUP BY FUNCTION('YEAR', e.expenseDate), FUNCTION('WEEK', e.expenseDate) " +
+            "ORDER BY year DESC, week")
+    List<Object[]> findWeeklyExpense(@Param("memberId") Long memberId,
+                                      @Param("startDate") LocalDate startDate,
+                                      @Param("endDate") LocalDate endDate);
+
+    @Query("SELECT e.expenseDate, SUM(e.amount) " +
+            "FROM Expense e " +
+            "WHERE e.member.id = :memberId " +
+            "AND e.expenseDate BETWEEN :startDate AND :endDate " +
+            "GROUP BY e.expenseDate " +
+            "ORDER BY e.expenseDate")
+    List<Object[]> findDailyExpense(@Param("memberId") Long memberId,
+                                     @Param("startDate") LocalDate startDate,
+                                     @Param("endDate") LocalDate endDate);
+
+
+    @Query("SELECT e.payment, SUM(e.amount) " +
+            "FROM Expense e " +
+            "WHERE e.member.id = :memberId " +
+            "AND e.expenseDate BETWEEN :startDate AND :endDate " +
+            "GROUP BY e.payment")
+    List<Object[]> findWeeklyExpenseByPaymentMethod(@Param("memberId") Long memberId,
+                                                    @Param("startDate") LocalDate startDate,
+                                                    @Param("endDate") LocalDate endDate);
+
+}
+

--- a/src/main/java/capstone/donworry/statistics/service/StatisticsService.java
+++ b/src/main/java/capstone/donworry/statistics/service/StatisticsService.java
@@ -57,13 +57,13 @@ public class StatisticsService {
             throw new EntityNotFoundException("회원 정보를 찾을 수 없습니다.");
         }
 
-        // 일별 소비
+
         List<Object[]> dailyResult = expenseStatisticsRepository.findDailyExpense(memberId, startDate, endDate);
         List<DailyExpenseDTO> dailyExpenses = dailyResult.stream()
                 .map(row -> new DailyExpenseDTO((LocalDate) row[0], (Long) row[1]))
                 .collect(Collectors.toList());
 
-        // 결제수단별 소비
+
         List<Object[]> paymentResult = expenseStatisticsRepository.findExpenseByPaymentMethod(memberId, startDate, endDate);
         List<PaymentExpenseDTO> paymentExpenses = paymentResult.stream()
                 .map(row -> new PaymentExpenseDTO((PaymentMethod) row[0], (Long) row[1]))
@@ -101,24 +101,24 @@ public class StatisticsService {
             throw new EntityNotFoundException("회원 정보를 찾을 수 없습니다.");
         }
 
-        // 1. 지출 목록
+
         List<Object[]> expenseRows = expenseStatisticsRepository.findExpensesByCategory(memberId, category, startDate, endDate);
         List<ExpenseItemDTO> expenses = expenseRows.stream()
                 .map(row -> new ExpenseItemDTO(
-                        (Long) row[0],           // id
-                        (String) row[1],         // title
-                        (Long) row[2],           // amount
-                        (PaymentMethod) row[3],  // payment method
-                        (LocalDate) row[4]       // date
+                        (Long) row[0],
+                        (String) row[1],
+                        (Long) row[2],
+                        (PaymentMethod) row[3],
+                        (LocalDate) row[4]
                 ))
                 .collect(Collectors.toList());
 
-        // 2. 결제수단별 총액
+
         List<Object[]> paymentRows = expenseStatisticsRepository.findPaymentSummaryByCategory(memberId, category, startDate, endDate);
         List<PaymentExpenseDTO> paymentExpenses = paymentRows.stream()
                 .map(row -> new PaymentExpenseDTO(
-                        (PaymentMethod) row[0],         // payment method
-                        (Long) row[1]            // total amount
+                        (PaymentMethod) row[0],
+                        (Long) row[1]
                 ))
                 .collect(Collectors.toList());
 

--- a/src/main/java/capstone/donworry/statistics/service/StatisticsService.java
+++ b/src/main/java/capstone/donworry/statistics/service/StatisticsService.java
@@ -1,11 +1,11 @@
 package capstone.donworry.statistics.service;
 
+import capstone.donworry.expense.domain.ExpenseCategory;
+import capstone.donworry.expense.domain.PaymentMethod;
 import capstone.donworry.member.domain.Member;
 import capstone.donworry.member.repository.MemberRepository;
-import capstone.donworry.statistics.dto.DailyExpenseDTO;
-import capstone.donworry.statistics.dto.PaymentExpenseDTO;
+import capstone.donworry.statistics.dto.*;
 import capstone.donworry.statistics.repository.ExpenseStatisticsRepository;
-import capstone.donworry.statistics.dto.WeeklyExpenseDTO;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -13,6 +13,7 @@ import org.springframework.stereotype.Service;
 import java.time.LocalDate;
 import java.time.temporal.WeekFields;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 @Service
@@ -51,34 +52,78 @@ public class StatisticsService {
                 .collect(Collectors.toList());
     }
 
-    public List<DailyExpenseDTO> getDailyExpense(Long memberId, LocalDate startDate, LocalDate endDate){
-        if(!memberRepository.existsById(memberId)){
-            throw new EntityNotFoundException("회원 정보를 찾을 수 없습니다.");
-        }
-
-        List<Object[]> result = expenseStatisticsRepository.findDailyExpense(memberId, startDate, endDate);
-
-        return result.stream()
-                .map(row -> new DailyExpenseDTO(
-                        (LocalDate) row[0],
-                        (Long) row[1]
-                ))
-                .collect(Collectors.toList());
-    }
-
-    public List<PaymentExpenseDTO> getWeeklyPaymentExpense(Long memberId, LocalDate startDate, LocalDate endDate) {
+    public WeeklyDetailExpenseDTO getWeeklyDetailStatistics(Long memberId, LocalDate startDate, LocalDate endDate) {
         if (!memberRepository.existsById(memberId)) {
             throw new EntityNotFoundException("회원 정보를 찾을 수 없습니다.");
         }
 
-        List<Object[]> result = expenseStatisticsRepository.findWeeklyExpenseByPaymentMethod(memberId, startDate, endDate);
+        // 일별 소비
+        List<Object[]> dailyResult = expenseStatisticsRepository.findDailyExpense(memberId, startDate, endDate);
+        List<DailyExpenseDTO> dailyExpenses = dailyResult.stream()
+                .map(row -> new DailyExpenseDTO((LocalDate) row[0], (Long) row[1]))
+                .collect(Collectors.toList());
 
-        return result.stream()
-                .map(row -> new PaymentExpenseDTO(
-                        (String) row[0],
-                        (Long) row[1]
+        // 결제수단별 소비
+        List<Object[]> paymentResult = expenseStatisticsRepository.findExpenseByPaymentMethod(memberId, startDate, endDate);
+        List<PaymentExpenseDTO> paymentExpenses = paymentResult.stream()
+                .map(row -> new PaymentExpenseDTO((PaymentMethod) row[0], (Long) row[1]))
+                .collect(Collectors.toList());
+
+        return new WeeklyDetailExpenseDTO(dailyExpenses, paymentExpenses);
+    }
+
+
+
+    public MonthlyStatisticsDTO getMonthlyStatistics(Long memberId, LocalDate startDate, LocalDate endDate) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new EntityNotFoundException("회원 정보를 찾을 수 없습니다."));
+
+        Long totalExpense = expenseStatisticsRepository.findMonthlyTotalExpense(memberId, startDate, endDate);
+        Long goalAmount = member.getGoalAmount();
+
+        List<CategoryExpenseDTO> categoryExpenses = expenseStatisticsRepository
+                .findMonthlyCategoryExpense(memberId, startDate, endDate)
+                .stream()
+                .map(row -> new CategoryExpenseDTO((ExpenseCategory) row[0], (Long) row[1]))
+                .collect(Collectors.toList());
+
+        List<PaymentExpenseDTO> paymentExpenses = expenseStatisticsRepository
+                .findExpenseByPaymentMethod(memberId, startDate, endDate)
+                .stream()
+                .map(row -> new PaymentExpenseDTO((PaymentMethod) row[0], (Long) row[1]))
+                .collect(Collectors.toList());
+
+        return new MonthlyStatisticsDTO(totalExpense, goalAmount, categoryExpenses, paymentExpenses);
+    }
+
+    public CategoryExpenseDetailDTO getCategoryExpenseDetail(Long memberId, ExpenseCategory category, LocalDate startDate, LocalDate endDate) {
+        if (!memberRepository.existsById(memberId)) {
+            throw new EntityNotFoundException("회원 정보를 찾을 수 없습니다.");
+        }
+
+        // 1. 지출 목록
+        List<Object[]> expenseRows = expenseStatisticsRepository.findExpensesByCategory(memberId, category, startDate, endDate);
+        List<ExpenseItemDTO> expenses = expenseRows.stream()
+                .map(row -> new ExpenseItemDTO(
+                        (Long) row[0],           // id
+                        (String) row[1],         // title
+                        (Long) row[2],           // amount
+                        (PaymentMethod) row[3],  // payment method
+                        (LocalDate) row[4]       // date
                 ))
                 .collect(Collectors.toList());
+
+        // 2. 결제수단별 총액
+        List<Object[]> paymentRows = expenseStatisticsRepository.findPaymentSummaryByCategory(memberId, category, startDate, endDate);
+        List<PaymentExpenseDTO> paymentExpenses = paymentRows.stream()
+                .map(row -> new PaymentExpenseDTO(
+                        (PaymentMethod) row[0],         // payment method
+                        (Long) row[1]            // total amount
+                ))
+                .collect(Collectors.toList());
+
+        return new CategoryExpenseDetailDTO(expenses, paymentExpenses);
     }
+
 
 }

--- a/src/main/java/capstone/donworry/statistics/service/StatisticsService.java
+++ b/src/main/java/capstone/donworry/statistics/service/StatisticsService.java
@@ -1,0 +1,84 @@
+package capstone.donworry.statistics.service;
+
+import capstone.donworry.member.domain.Member;
+import capstone.donworry.member.repository.MemberRepository;
+import capstone.donworry.statistics.dto.DailyExpenseDTO;
+import capstone.donworry.statistics.dto.PaymentExpenseDTO;
+import capstone.donworry.statistics.repository.ExpenseStatisticsRepository;
+import capstone.donworry.statistics.dto.WeeklyExpenseDTO;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.time.temporal.WeekFields;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class StatisticsService {
+
+    private final ExpenseStatisticsRepository expenseStatisticsRepository;
+    private final MemberRepository memberRepository;
+
+    public List<WeeklyExpenseDTO> getWeeklyExpense(Long memberId, LocalDate startDate, LocalDate endDate) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new EntityNotFoundException("회원 정보를 찾을 수 없습니다."));
+
+        Long goalAmount = member.getGoalAmount();
+        int daysInMonth = startDate.lengthOfMonth();
+        long dailyGoal = goalAmount / daysInMonth;
+
+        List<Object[]> result = expenseStatisticsRepository.findWeeklyExpense(memberId, startDate, endDate);
+
+        return result.stream()
+                .map(row -> {
+                    int year = (Integer) row[0];
+                    int week = (Integer) row[1];
+                    Long totalSpent = (Long) row[2];
+
+                    LocalDate weekStart = LocalDate
+                            .now()
+                            .withYear(year)
+                            .with(WeekFields.ISO.weekOfYear(), week)
+                            .with(WeekFields.ISO.dayOfWeek(), 1);
+                    LocalDate weekEnd = weekStart.plusDays(6);
+
+                    return new WeeklyExpenseDTO(
+                            year, week, totalSpent, weekStart, weekEnd, goalAmount);
+                })
+                .collect(Collectors.toList());
+    }
+
+    public List<DailyExpenseDTO> getDailyExpense(Long memberId, LocalDate startDate, LocalDate endDate){
+        if(!memberRepository.existsById(memberId)){
+            throw new EntityNotFoundException("회원 정보를 찾을 수 없습니다.");
+        }
+
+        List<Object[]> result = expenseStatisticsRepository.findDailyExpense(memberId, startDate, endDate);
+
+        return result.stream()
+                .map(row -> new DailyExpenseDTO(
+                        (LocalDate) row[0],
+                        (Long) row[1]
+                ))
+                .collect(Collectors.toList());
+    }
+
+    public List<PaymentExpenseDTO> getWeeklyPaymentExpense(Long memberId, LocalDate startDate, LocalDate endDate) {
+        if (!memberRepository.existsById(memberId)) {
+            throw new EntityNotFoundException("회원 정보를 찾을 수 없습니다.");
+        }
+
+        List<Object[]> result = expenseStatisticsRepository.findWeeklyExpenseByPaymentMethod(memberId, startDate, endDate);
+
+        return result.stream()
+                .map(row -> new PaymentExpenseDTO(
+                        (String) row[0],
+                        (Long) row[1]
+                ))
+                .collect(Collectors.toList());
+    }
+
+}


### PR DESCRIPTION

getWeeklyExpenseByMonth: 프론트에서 년,월 보내주면 db에서 검색후 주별로 나눠서 데이터반환
getDailyExpenseByWeek: 특정 주 선택시 그 주에 속하는 일별 소비합계 반환
getWeeklyPaymentStats: 특정 주의 지불 방법별 소비합계 반환

getWeeklyExpenseByMonth-> 한달소비목표금액/n을 해서 같이 전달하도록 설정해두었는데 이건 이후에 수정해야할 수도